### PR TITLE
create-dcim-api-tests

### DIFF
--- a/api/endpoints/dcim-ep.ts
+++ b/api/endpoints/dcim-ep.ts
@@ -7,6 +7,116 @@ export class DcimEp extends BaseRequest {
     private devicesURL: string = "api/dcim/devices/";
     private cpntsURL: string = "api/accounts/";
     private accountsURL: string = "api/dcim/cpnts/";
+    private deviceTypesURL: string = "api/dcim/device-types/";
+    private deviceRolesURL: string = "api/dcim/device-roles/";
+    private dcimCpntsURL: string = "api/dcim/cpnts/";
+    private dcimCpntTypesURL: string = "api/dcim/cpnt-types/";
+    private dcimVirtualChassisURL: string = "api/dcim/virtual-chassis/";
+    private dcimVirtualDeviceContextsURL: string = "api/dcim/virtual-device-contexts/";
+    private dcimEnterpriseSoftwareURL: string = "api/dcim/enterprise-software/";
+    private dcimSoftwareComponentsURL: string = "api/dcim/software-components/";
+    private dcimAccountsURL: string = "api/dcim/accounts/";
+    private dcimSuitesURL: string = "api/dcim/suites/";
+    private dcimPlatformsURL: string = "api/dcim/platforms/";
+    private dcimSoftwareURL: string = "api/dcim/software/";
+    private dcimVendorsURL: string = "api/dcim/vendors/";
+    private dcimVendorTypesURL: string = "api/dcim/vendor-types/";
+    private dcimContractTypesURL: string = "api/dcim/contract-types/";
+    private dcimContractLevelsURL: string = "api/dcim/contract-levels/";
+    private dcimProjectsURL: string = "api/dcim/projects/";
+    private dcimBusinessUnitsURL: string = "api/dcim/business-units/";
+    private dcimDepartmentsURL: string = "api/dcim/departments/";
+    private dcimOrdersURL: string = "api/dcim/orders/";
+    private dcimRulesEngineURL: string = "api/dcim/rules-engine/";
+    private dcimSitesURL: string = "api/dcim/sites/";
+    private dcimRegionsURL: string = "api/dcim/regions/";
+    private dcimSiteGroupsURL: string = "api/dcim/site-groups/";
+    private dcimRacksURL: string = "api/dcim/racks/";
+    private dcimRackRolesURL: string = "api/dcim/rack-roles/";
+    private dcimRackReservationsURL: string = "api/dcim/rack-reservations/";
+
+    async getDcimRackReservationsRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimRackReservationsURL, auth, params);
+    }
+
+    async getDcimRackRolesRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimRackRolesURL, auth, params);
+    }
+
+    async getDcimRacksRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimRacksURL, auth, params);
+    }
+
+    async getDcimSiteGroupsRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimSiteGroupsURL, auth, params);
+    }
+
+    async getDcimRegionsRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimRegionsURL, auth, params);
+    }
+
+    async getDcimSitesRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimSitesURL, auth, params);
+    }
+
+    async getDcimRulesEngineRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimRulesEngineURL, auth, params);
+    }
+
+    async getDcimOrdersRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimOrdersURL, auth, params);
+    }
+
+    async getDcimDepartmentsRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimDepartmentsURL, auth, params);
+    }
+
+    async getDcimBusinessUnitsRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimBusinessUnitsURL, auth, params);
+    }
+
+    async getDcimProjectsRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimProjectsURL, auth, params);
+    }
+
+    async getDcimContractLevelsRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimContractLevelsURL, auth, params);
+    }
+
+    async getDcimContractTypesRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimContractTypesURL, auth, params);
+    }
+
+    async getDcimVendorTypesRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimVendorTypesURL, auth, params);
+    }
+
+    async getDcimVendorsRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimVendorsURL, auth, params);
+    }
+    async getDcimSoftwareRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimSoftwareURL, auth, params);
+    }
+
+    async getDcimPlatformsRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimPlatformsURL, auth, params);
+    }
+
+    async getDcimSuitesRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimSuitesURL, auth, params);
+    }
+
+    async getDcimAccountsRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimAccountsURL, auth, params);
+    }
+
+    async getDcimSoftwareComponentsRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimSoftwareComponentsURL, auth, params);
+    }
+
+    async getDcimEnterpriseSoftwareRequest(auth: string, params?: Record<string, any>) {
+        return await this.getRequestWithParams(this.dcimEnterpriseSoftwareURL, auth, params);
+    }
 
     async getContractsRequest(auth: string, params?: Record<string, any>) {
         return await this.getRequestWithParams(this.contractsURL, auth, params);
@@ -34,5 +144,29 @@ export class DcimEp extends BaseRequest {
 
     async getAccountsRequest(auth: string, params?: Record<string, any>) {
         return await this.getRequestWithParams(this.accountsURL, auth, params);
+    }
+
+    async getDcimDeviceTypesRequest(auth: string) {
+        return await this.getRequest(this.deviceTypesURL, auth);
+    }
+
+    async getDcimDeviceRolesRequest(auth: string) {
+        return await this.getRequest(this.deviceRolesURL, auth);
+    }
+
+    async getDcimCpntsRequest(auth: string) {
+        return await this.getRequest(this.dcimCpntsURL, auth);
+    }
+
+    async getDcimCpntTypesRequest(auth: string) {
+        return await this.getRequest(this.dcimCpntTypesURL, auth);
+    }
+
+    async getDcimVirtualDeviceContextsRequest(auth: string) {
+        return await this.getRequest(this.dcimVirtualDeviceContextsURL, auth);
+    }
+
+    async getDcimVirtualChassisRequest(auth: string) {
+        return await this.getRequest(this.dcimVirtualChassisURL, auth);
     }
 }

--- a/api/endpoints/tenancy-ep.ts
+++ b/api/endpoints/tenancy-ep.ts
@@ -1,0 +1,9 @@
+import {BaseRequest} from "../base-request";
+
+export class TenancyEp extends BaseRequest {
+    private tenantsUrl: string = "api/tenancy/tenants/";
+
+    async getTenantsRequest(auth: string) {
+        return await this.getRequest(this.tenantsUrl, auth);
+    }
+}

--- a/tests/dcim.test.ts
+++ b/tests/dcim.test.ts
@@ -70,4 +70,220 @@ test.describe('Dcim Endpoints Tests', () => {
         expect(response.status()).toEqual(200);
         expect(response.json()).not.toBeNull();
     });
+
+    test('Get dcim device types request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimDeviceTypesRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim device roles request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimDeviceRolesRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim cpnts request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimCpntsRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim cpnt types request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimCpntTypesRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim virtual chassis request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimVirtualChassisRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim virtual device contexts request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimVirtualDeviceContextsRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim enterprise software request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimEnterpriseSoftwareRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim software components request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimSoftwareComponentsRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim accounts request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimAccountsRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim suites request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimSuitesRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim platforms request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimPlatformsRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim software request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimSoftwareRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim vendors request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimVendorsRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim vendor types request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimVendorTypesRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim contracts types request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimContractTypesRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim contracts levels request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimContractLevelsRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim projects request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimProjectsRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim business units request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimBusinessUnitsRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim departments request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimDepartmentsRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim orders request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimOrdersRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim rules engine request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimRulesEngineRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim sites request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimSitesRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim regions request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimRegionsRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim site groups request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimSiteGroupsRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim racks request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimRacksRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim rack roles request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimRackRolesRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
+
+    test('Get dcim rack reservations request test', async () => {
+        const dcimEp = new DcimEp();
+        const response = await dcimEp.getDcimRackReservationsRequest(apiToken!);
+
+        expect(response.status()).toEqual(200);
+        expect(response.json()).not.toBeNull();
+    });
 });


### PR DESCRIPTION
Expanded `dcim-ep.ts` with additional API endpoints and their respective request methods. Also introduced unit tests to ensure API compatibility. Added `tenancy-ep.ts` to handle tenancy-related API requests.